### PR TITLE
Output dir fix

### DIFF
--- a/components/nonmem/src/prepare_model.rs
+++ b/components/nonmem/src/prepare_model.rs
@@ -37,7 +37,8 @@ pub fn prepare_model(
 
     let parent_dir = path.parent().expect("models to not be at the root of FS");
     let file_name = path.file_name().expect("models to have a filename");
-    let model_name = path.file_stem()
+    let model_name = path
+        .file_stem()
         .expect("models to have a filename")
         .to_string_lossy()
         .to_string(); // e.g., "run001"


### PR DESCRIPTION
```
[90m[[0m2025-10-16T16:42:23Z [34mDEBUG[0m pharos[90m][0m Loading pharos config file: "/data/user-homes/matthews/Projects/pharos-test/model/nonmem/submission-log/pharos.toml"
[90m[[0m2025-10-16T16:42:23Z [34mDEBUG[0m pharos[90m][0m Going to run: ["/data/user-homes/matthews/Projects/pharos-test/model/nonmem/1001.mod"]
Running model: "/data/user-homes/matthews/Projects/pharos-test/model/nonmem/1001.mod"
[90m[[0m2025-10-16T16:42:23Z [34mDEBUG[0m nonmem[90m][0m Parallel execution disabled
[90m[[0m2025-10-16T16:42:23Z [34mDEBUG[0m nonmem[90m][0m Model output dir will be "/data/user-homes/matthews/Projects/pharos-test/model/nonmem/1001.mod"
[90m[[0m2025-10-16T16:42:23Z [34mDEBUG[0m nonmem[90m][0m Model "/data/user-homes/matthews/Projects/pharos-test/model/nonmem/1001.mod" will be running in "/data/user-homes/matthews/Projects/pharos-test/model/nonmem/1001.mod"
Model failed: "/data/user-homes/matthews/Projects/pharos-test/model/nonmem/1001.mod": failed to create directory `/data/user-homes/matthews/Projects/pharos-test/model/nonmem/1001.mod`: File exists (os error 17)
```

Models were incorrectly trying to be saved to mod file.

output dir from prepare model was using file name instead of file_stem.

```
[90m[[0m2025-10-16T16:59:51Z [34mDEBUG[0m pharos[90m][0m Loading pharos config file: "/data/user-homes/matthews/Projects/pharos-test/model/nonmem/submission-log/pharos.toml"
[90m[[0m2025-10-16T16:59:51Z [34mDEBUG[0m pharos[90m][0m Going to run: ["/data/user-homes/matthews/Projects/pharos-test/model/nonmem/1001.mod"]
Running model: "/data/user-homes/matthews/Projects/pharos-test/model/nonmem/1001.mod"
[90m[[0m2025-10-16T16:59:51Z [34mDEBUG[0m nonmem[90m][0m Parallel execution disabled
[90m[[0m2025-10-16T16:59:51Z [34mDEBUG[0m nonmem[90m][0m Model output dir will be "/data/user-homes/matthews/Projects/pharos-test/model/nonmem/1001"
...
Model completed successfully: "/data/user-homes/matthews/Projects/pharos-test/model/nonmem/1001.mod"
```