### PR TITLE
adding back nmtranresult

### DIFF
--- a/components/nonmem/src/check.rs
+++ b/components/nonmem/src/check.rs
@@ -1,13 +1,21 @@
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, anyhow};
 use fs_err as fs;
 
 use crate::Model;
 use config::NonmemConfig;
 
-pub fn check_model(nonmem_config: &NonmemConfig, model_file: &Path) -> Result<()> {
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NmtranResult {
+    pub success: bool,
+    pub exit_code: i32,
+    pub stdout: String,
+}
+
+pub fn check_model(nonmem_config: &NonmemConfig, model_file: &Path) -> Result<NmtranResult> {
     let nmtrans_exec = nonmem_config.get_nmtrans_executable_path(None)?;
 
     let model_dir = model_file
@@ -23,17 +31,14 @@ pub fn check_model(nonmem_config: &NonmemConfig, model_file: &Path) -> Result<()
     fs::write(&model_tmp_path, model_content)?;
     log::debug!("Model written to {}", model_tmp_path.display());
     let file = fs::File::open(model_tmp_path)?;
-    let status = Command::new(nmtrans_exec)
+    let output = Command::new(nmtrans_exec)
         .stdin(Stdio::from(file.into_file()))
         .current_dir(tmp_dir.path())
-        .status()?;
+        .output()?;
 
-    if !status.success() {
-        bail!(
-            "nmtrans failed with exit code: {}",
-            status.code().unwrap_or(-1)
-        );
-    }
-
-    Ok(())
+    Ok(NmtranResult {
+        success: output.status.success(),
+        exit_code: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -299,7 +299,19 @@ fn try_main() -> Result<()> {
             }
             NonmemCommands::Check { model } => {
                 let nonmem_config = load_nonmem_config(None)?;
-                check_model(&nonmem_config, Path::new(&model))?;
+
+                match check_model(&nonmem_config, Path::new(&model)) {
+                    Err(e) => eprintln!("{e:#}"),
+                    Ok(res) if res.success => {
+                        println!("{}", res.stdout);
+                    }
+                    Ok(res) => {
+                        eprintln!(
+                            "{}\nnmtran failed with exit code {:?}",
+                            res.stdout, res.exit_code
+                        );
+                    }
+                }
             }
             NonmemCommands::Run { model, run_options } => {
                 let nonmem_config = load_nonmem_config(run_options.nonmem_version.as_deref())?;


### PR DESCRIPTION
This is purely so I can get the stdout from nmtran in R. On nmtran error check_model no longer bails.

New behavior
```
matthews@uat-ee|LoginNode uat-ee:~/Packages/hyperion$ pharos nonmem check vignettes/test_data/models/onecmt/run004.mod
 
 AN ERROR WAS FOUND IN THE CONTROL STATEMENTS.
 
AN ERROR WAS FOUND ON LINE 11 AT THE APPROXIMATE POSITION NOTED:
 TVCL = THETA1
        X     
 THE CHARACTERS IN ERROR ARE: THETA1
  208  UNDEFINED VARIABLE.

nmtran failed with exit code 4
```

Old behavior:
```
matthews@uat-ee|LoginNode uat-ee:~/Packages/hyperion$ pharos nonmem check vignettes/test_data/models/onecmt/run004.mod
 
 AN ERROR WAS FOUND IN THE CONTROL STATEMENTS.
 
AN ERROR WAS FOUND ON LINE 11 AT THE APPROXIMATE POSITION NOTED:
 TVCL = THETA1
        X     
 THE CHARACTERS IN ERROR ARE: THETA1
  208  UNDEFINED VARIABLE.
nmtrans failed with exit code: 4
```