### PR TITLE
fix parameter retrieval from different ParameterOrderings

### DIFF
--- a/components/nonmem/src/parsing/model.rs
+++ b/components/nonmem/src/parsing/model.rs
@@ -944,14 +944,12 @@ fn get_block_parameter_names<'a, T: ParamName>(
                     _ => unreachable!(),
                 };
 
-                for (param_idx, (row, col)) in
-                    ordering.get_coordinates(*size).into_iter().enumerate()
-                {
-                    if param_idx >= parameters.len() {
+                for (storage_idx, row, col) in ordering.get_indexed_coordinates(*size) {
+                    if storage_idx >= parameters.len() {
                         break;
                     }
 
-                    let param = &parameters[param_idx];
+                    let param = &parameters[storage_idx];
                     let param_row = base_counter + row;
                     let param_col = base_counter + col;
                     let param_name = format!("{param_prefix}({param_row},{param_col})");
@@ -1058,6 +1056,37 @@ mod tests {
         let invalid = model.parse_comments(CommentType::Type1);
         assert!(invalid.is_empty());
         assert_debug_snapshot!(model);
+    }
+
+    #[test]
+    fn block_same_advances_parameter_positions() {
+        let input = r#"
+$PROBLEM same block indexing
+$OMEGA BLOCK(1)
+0.1
+$OMEGA BLOCK(1) SAME
+$OMEGA BLOCK(1)
+0.2
+"#;
+
+        let model = Model::parse(input).unwrap();
+        let omega_names = model
+            .get_omega_parameters(ParameterOrdering::RowMajor)
+            .unwrap();
+
+        let names: Vec<_> = omega_names
+            .into_iter()
+            .map(|(param_name, _eta_label, _param)| param_name)
+            .collect();
+
+        assert_eq!(
+            names,
+            vec![
+                "OMEGA(1,1)".to_string(),
+                "OMEGA(2,2)".to_string(),
+                "OMEGA(3,3)".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/components/nonmem/src/parsing/utils.rs
+++ b/components/nonmem/src/parsing/utils.rs
@@ -174,6 +174,28 @@ impl ParameterOrdering {
                 .collect(),
         }
     }
+
+    /// Returns (storage_idx, row, col) for each coordinate in this ordering.
+    ///
+    /// `storage_idx` is the row-major index into the block parameter array, so
+    /// callers can emit names in any ordering while still selecting the correct
+    /// stored parameter.
+    pub fn get_indexed_coordinates(&self, block_size: usize) -> Vec<(usize, usize, usize)> {
+        let storage_coords = ParameterOrdering::RowMajor.get_coordinates(block_size);
+
+        self.get_coordinates(block_size)
+            .into_iter()
+            .map(|(row, col)| {
+                let storage_idx = storage_coords
+                    .iter()
+                    .position(|&(storage_row, storage_col)| {
+                        storage_row == row && storage_col == col
+                    })
+                    .expect("requested coordinate must exist in row-major storage");
+                (storage_idx, row, col)
+            })
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -244,5 +266,22 @@ mod tests {
             let expected = expected.map(|s| s.to_string());
             assert_eq!(result, expected, "Failed for path: {}", path);
         }
+    }
+
+    #[test]
+    fn can_map_column_major_coordinates_to_row_major_storage() {
+        let indexed = ParameterOrdering::ColumnMajor.get_indexed_coordinates(3);
+
+        assert_eq!(
+            indexed,
+            vec![
+                (0, 0, 0),
+                (1, 1, 0),
+                (3, 2, 0),
+                (2, 1, 1),
+                (4, 2, 1),
+                (5, 2, 2),
+            ]
+        );
     }
 }


### PR DESCRIPTION
On main:

model has this $OMEGA block
```
$OMEGA BLOCK(3)
0.1     ;OM1 CL :EXP
0.01
0.1     ;OM2 VC :EXP
0.01
0.01
0.1     ;OM3 KA :EXP
```

When a type is specified gradient columns are renamed using parsed parameter names.
```
> get_gradients(mod)
  iteration method GRD.THETA1.  GRD.THETA2.  GRD.THETA3. GRD.OM1..CL.. GRD.ETA1.ETA2. GRD.OM2..VC..   GRD.ETA2. GRD.ETA2.ETA3. GRD.OM3..KA..   GRD.EPS1.   GRD.EPS2.
1         0   FOCE   -6.795330 -125.2010000 101.39500000    15.0797000    -60.9588000   11.19590000 53.12340000    22.97400000   -5.02886000 246.7050000 -3.62286000
2         5   FOCE   74.677700  -28.5684000   4.17953000   -35.2056000     36.8488000   -3.39135000  3.77616000    21.81640000    2.20187000  78.4657000 -2.86094000
3        10   FOCE   -8.172050   40.7216000  30.46460000    14.0554000     19.0755000   -5.66478000 -2.85575000   -10.05750000    6.59544000  64.4603000 -4.72881000
4        15   FOCE  -12.201800   13.4657000  -4.35255000    -1.7819800     -4.3619800    1.96661000  1.17123000     1.19691000    0.51222600  -6.2972700 -1.68459000
5        20   FOCE    0.268557   -0.2239050  -0.04881340    -0.3959700      0.3779430    0.05385540 -0.30942800    -0.09543490    0.09785550   0.1096790  0.01887700
6        25   FOCE   -0.119817    0.0106759  -0.00588712     0.0209273     -0.0179141   -0.00216862  0.00816083    -0.00315344    0.00100826   0.0114463 -0.00155922
```
Without having a specified type the renaming falls back to generic ETA labels, so the bug is masked:
```
> get_gradients(mod)
  iteration method GRD.THETA1.  GRD.THETA2.  GRD.THETA3.   GRD.ETA1. GRD.ETA1.ETA2. GRD.ETA1.ETA3.   GRD.ETA2. GRD.ETA2.ETA3.   GRD.ETA3.   GRD.EPS1.   GRD.EPS2.
1         0   FOCE   -6.795330 -125.2010000 101.39500000  15.0797000    -60.9588000    11.19590000 53.12340000    22.97400000 -5.02886000 246.7050000 -3.62286000
2         5   FOCE   74.677700  -28.5684000   4.17953000 -35.2056000     36.8488000    -3.39135000  3.77616000    21.81640000  2.20187000  78.4657000 -2.86094000
3        10   FOCE   -8.172050   40.7216000  30.46460000  14.0554000     19.0755000    -5.66478000 -2.85575000   -10.05750000  6.59544000  64.4603000 -4.72881000
4        15   FOCE  -12.201800   13.4657000  -4.35255000  -1.7819800     -4.3619800     1.96661000  1.17123000     1.19691000  0.51222600  -6.2972700 -1.68459000
5        20   FOCE    0.268557   -0.2239050  -0.04881340  -0.3959700      0.3779430     0.05385540 -0.30942800    -0.09543490  0.09785550   0.1096790  0.01887700
6        25   FOCE   -0.119817    0.0106759  -0.00588712   0.0209273     -0.0179141    -0.00216862  0.00816083    -0.00315344  0.00100826   0.0114463 -0.00155922
```
The bug is shown in the 8th column - with parsed names it is the incorrect OM2 (VC) when it should be ETA1:ETA3

## This PR
After updating to this fix we get the correct names:
```
> get_gradients(mod)
  iteration method GRD.THETA1.  GRD.THETA2.  GRD.THETA3. GRD.OM1..CL.. GRD.ETA1.ETA2. GRD.ETA1.ETA3. GRD.OM2..VC.. GRD.ETA2.ETA3. GRD.OM3..KA..   GRD.EPS1.   GRD.EPS2.
1         0   FOCE   -6.795330 -125.2010000 101.39500000    15.0797000    -60.9588000    11.19590000   53.12340000    22.97400000   -5.02886000 246.7050000 -3.62286000
2         5   FOCE   74.677700  -28.5684000   4.17953000   -35.2056000     36.8488000    -3.39135000    3.77616000    21.81640000    2.20187000  78.4657000 -2.86094000
3        10   FOCE   -8.172050   40.7216000  30.46460000    14.0554000     19.0755000    -5.66478000   -2.85575000   -10.05750000    6.59544000  64.4603000 -4.72881000
4        15   FOCE  -12.201800   13.4657000  -4.35255000    -1.7819800     -4.3619800     1.96661000    1.17123000     1.19691000    0.51222600  -6.2972700 -1.68459000
5        20   FOCE    0.268557   -0.2239050  -0.04881340    -0.3959700      0.3779430     0.05385540   -0.30942800    -0.09543490    0.09785550   0.1096790  0.01887700
6        25   FOCE   -0.119817    0.0106759  -0.00588712     0.0209273     -0.0179141    -0.00216862    0.00816083    -0.00315344    0.00100826   0.0114463 -0.00155922
```

```
> get_gradients(mod)
  iteration method GRD.THETA1.  GRD.THETA2.  GRD.THETA3.   GRD.ETA1. GRD.ETA1.ETA2. GRD.ETA1.ETA3.   GRD.ETA2. GRD.ETA2.ETA3.   GRD.ETA3.   GRD.EPS1.   GRD.EPS2.
1         0   FOCE   -6.795330 -125.2010000 101.39500000  15.0797000    -60.9588000    11.19590000 53.12340000    22.97400000 -5.02886000 246.7050000 -3.62286000
2         5   FOCE   74.677700  -28.5684000   4.17953000 -35.2056000     36.8488000    -3.39135000  3.77616000    21.81640000  2.20187000  78.4657000 -2.86094000
3        10   FOCE   -8.172050   40.7216000  30.46460000  14.0554000     19.0755000    -5.66478000 -2.85575000   -10.05750000  6.59544000  64.4603000 -4.72881000
4        15   FOCE  -12.201800   13.4657000  -4.35255000  -1.7819800     -4.3619800     1.96661000  1.17123000     1.19691000  0.51222600  -6.2972700 -1.68459000
5        20   FOCE    0.268557   -0.2239050  -0.04881340  -0.3959700      0.3779430     0.05385540 -0.30942800    -0.09543490  0.09785550   0.1096790  0.01887700
6        25   FOCE   -0.119817    0.0106759  -0.00588712   0.0209273     -0.0179141    -0.00216862  0.00816083    -0.00315344  0.00100826   0.0114463 -0.00155922
```