### PR TITLE
add copied_from field to metadata to use that instead of based_on dur…

### DIFF
--- a/components/nonmem/src/copy.rs
+++ b/components/nonmem/src/copy.rs
@@ -272,7 +272,7 @@ pub fn copy_model(
         }
         let metadata = ModelMetadata::new(
             options.based_on.clone(),
-            Some(original_filename.to_string()),
+            original_filename.to_string(),
             options.description.clone(),
         )?;
         metadata.save(new_model_name.as_ref(), to.parent().unwrap())?;

--- a/components/nonmem/src/copy.rs
+++ b/components/nonmem/src/copy.rs
@@ -268,7 +268,10 @@ pub fn copy_model(
     // Create metadata file
     if !options.no_metadata {
         if !options.based_on.is_empty() {
-            crate::model_metadata::validate_based_on(&options.based_on, to.parent().unwrap())?;
+            crate::model_metadata::validate_relative_paths_exist(
+                &options.based_on,
+                to.parent().unwrap(),
+            )?;
         }
         let metadata = ModelMetadata::new(
             options.based_on.clone(),

--- a/components/nonmem/src/copy.rs
+++ b/components/nonmem/src/copy.rs
@@ -100,6 +100,10 @@ pub struct CopyOptions {
     #[cfg_attr(feature = "cli", clap(long))]
     pub description: String,
 
+    /// Determines model hierarchy. Only use for nested models.
+    #[cfg_attr(feature = "cli", clap(long, value_delimiter = ','))]
+    pub based_on: Vec<String>,
+
     #[cfg_attr(feature = "cli", clap(long))]
     pub no_metadata: bool,
 }
@@ -263,8 +267,12 @@ pub fn copy_model(
 
     // Create metadata file
     if !options.no_metadata {
+        if !options.based_on.is_empty() {
+            crate::model_metadata::validate_based_on(&options.based_on, to.parent().unwrap())?;
+        }
         let metadata = ModelMetadata::new(
-            vec![original_filename.to_string()],
+            options.based_on.clone(),
+            Some(original_filename.to_string()),
             options.description.clone(),
         )?;
         metadata.save(new_model_name.as_ref(), to.parent().unwrap())?;

--- a/components/nonmem/src/lineage.rs
+++ b/components/nonmem/src/lineage.rs
@@ -234,6 +234,7 @@ mod tests {
                 name.to_string(),
                 ModelMetadata {
                     based_on,
+                    copied_from: None,
                     description,
                     tags,
                 },

--- a/components/nonmem/src/lineage.rs
+++ b/components/nonmem/src/lineage.rs
@@ -234,7 +234,7 @@ mod tests {
                 name.to_string(),
                 ModelMetadata {
                     based_on,
-                    copied_from: None,
+                    copied_from: String::new(),
                     description,
                     tags,
                 },

--- a/components/nonmem/src/model_metadata.rs
+++ b/components/nonmem/src/model_metadata.rs
@@ -12,7 +12,7 @@ pub struct ModelMetadata {
     /// Parent model(s) this model is based on
     #[serde(default)]
     pub based_on: Vec<String>,
-    /// Model this was mechanically copied from (set by copy_model; not user-editable)
+    /// Model this was mechanically copied from
     #[serde(default)]
     pub copied_from: String,
     /// Short description of the model
@@ -63,6 +63,7 @@ impl ModelMetadata {
         description: Option<String>,
         tags: Vec<String>,
         based_on: Vec<String>,
+        copied_from: Option<String>,
     ) -> Self {
         // Overwrite mode: replace fields that are provided
         if let Some(d) = description
@@ -75,6 +76,11 @@ impl ModelMetadata {
         }
         if !based_on.is_empty() {
             self.based_on = based_on;
+        }
+        if let Some(c) = copied_from
+            && !c.trim().is_empty()
+        {
+            self.copied_from = c;
         }
         self
     }
@@ -192,6 +198,7 @@ pub fn update_metadata_file(
     description: Option<String>,
     tags: Vec<String>,
     based_on: Vec<String>,
+    copied_from: Option<String>,
     overwrite: bool,
 ) -> Result<PathBuf> {
     let model_path = resolve_model_path(&input)?;
@@ -200,19 +207,28 @@ pub fn update_metadata_file(
 
     let tags_vec = clean_vec(tags);
     let based_on_vec = clean_vec(based_on);
+    let copied_from = copied_from
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
 
     validate_based_on(&based_on_vec, &model_dir)?;
+    if let Some(cf) = &copied_from {
+        validate_based_on(&vec![cf.clone()], &model_dir)?;
+    }
 
     let metadata = if metadata_path.exists() {
         let m = ModelMetadata::load(&metadata_path)?;
         if overwrite {
-            m.set(description, tags_vec, based_on_vec)
+            m.set(description, tags_vec, based_on_vec, copied_from)
         } else {
             m.update(description, tags_vec, based_on_vec)
         }
     } else {
-        let mut m =
-            ModelMetadata::new(based_on_vec, String::new(), description.unwrap_or_default())?;
+        let mut m = ModelMetadata::new(
+            based_on_vec,
+            copied_from.unwrap_or_default(),
+            description.unwrap_or_default(),
+        )?;
         m.tags = tags_vec;
         m
     };

--- a/components/nonmem/src/model_metadata.rs
+++ b/components/nonmem/src/model_metadata.rs
@@ -12,19 +12,27 @@ pub struct ModelMetadata {
     /// Parent model(s) this model is based on
     #[serde(default)]
     pub based_on: Vec<String>,
+    /// Model this was mechanically copied from (set by copy_model; not user-editable)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub copied_from: Option<String>,
     /// Short description of the model
     pub description: String,
     pub tags: Vec<String>,
 }
 
 impl ModelMetadata {
-    pub fn new(based_on: Vec<String>, description: String) -> Result<Self> {
+    pub fn new(
+        based_on: Vec<String>,
+        copied_from: Option<String>,
+        description: String,
+    ) -> Result<Self> {
         if description.trim().is_empty() {
             bail!("Please provide a description for the model")
         }
 
         Ok(Self {
             based_on,
+            copied_from,
             description,
             tags: Vec::new(),
         })
@@ -136,7 +144,10 @@ fn clean_vec(x: Vec<String>) -> Vec<String> {
 }
 
 // Validate that all based_on model files exist relative to the model directory
-fn validate_based_on(based_on_vec: &Vec<String>, model_dir: impl AsRef<Path>) -> Result<()> {
+pub(crate) fn validate_based_on(
+    based_on_vec: &Vec<String>,
+    model_dir: impl AsRef<Path>,
+) -> Result<()> {
     let model_dir = model_dir.as_ref();
     for based_on_path in based_on_vec {
         let full_path = model_dir.join(based_on_path);
@@ -204,7 +215,7 @@ pub fn update_metadata_file(
             m.update(description, tags_vec, based_on_vec)
         }
     } else {
-        let mut m = ModelMetadata::new(based_on_vec, description.unwrap_or_default())?;
+        let mut m = ModelMetadata::new(based_on_vec, None, description.unwrap_or_default())?;
         m.tags = tags_vec;
         m
     };

--- a/components/nonmem/src/model_metadata.rs
+++ b/components/nonmem/src/model_metadata.rs
@@ -145,20 +145,28 @@ fn clean_vec(x: Vec<String>) -> Vec<String> {
         .collect()
 }
 
-// Validate that all based_on model files exist relative to the model directory
-pub(crate) fn validate_based_on(
-    based_on_vec: &Vec<String>,
+fn clean_opt(x: Option<String>) -> Option<String> {
+    x.map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
+}
+
+fn validate_relative_path_exists(rel: &str, model_dir: &Path) -> Result<()> {
+    let full_path = model_dir.join(rel);
+    if !full_path.exists() {
+        bail!(
+            "Model file does not exist: {rel} (resolved to {})",
+            full_path.display()
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_relative_paths_exist(
+    paths: &[String],
     model_dir: impl AsRef<Path>,
 ) -> Result<()> {
     let model_dir = model_dir.as_ref();
-    for based_on_path in based_on_vec {
-        let full_path = model_dir.join(based_on_path);
-        if !full_path.exists() {
-            bail!(
-                "Based-on model file does not exist: {based_on_path} (resolved to {})",
-                full_path.display()
-            );
-        }
+    for p in paths {
+        validate_relative_path_exists(p, model_dir)?;
     }
     Ok(())
 }
@@ -207,13 +215,11 @@ pub fn update_metadata_file(
 
     let tags_vec = clean_vec(tags);
     let based_on_vec = clean_vec(based_on);
-    let copied_from = copied_from
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty());
+    let copied_from = clean_opt(copied_from);
 
-    validate_based_on(&based_on_vec, &model_dir)?;
+    validate_relative_paths_exist(&based_on_vec, &model_dir)?;
     if let Some(cf) = &copied_from {
-        validate_based_on(&vec![cf.clone()], &model_dir)?;
+        validate_relative_path_exists(cf, &model_dir)?;
     }
 
     let metadata = if metadata_path.exists() {

--- a/components/nonmem/src/model_metadata.rs
+++ b/components/nonmem/src/model_metadata.rs
@@ -13,19 +13,15 @@ pub struct ModelMetadata {
     #[serde(default)]
     pub based_on: Vec<String>,
     /// Model this was mechanically copied from (set by copy_model; not user-editable)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub copied_from: Option<String>,
+    #[serde(default)]
+    pub copied_from: String,
     /// Short description of the model
     pub description: String,
     pub tags: Vec<String>,
 }
 
 impl ModelMetadata {
-    pub fn new(
-        based_on: Vec<String>,
-        copied_from: Option<String>,
-        description: String,
-    ) -> Result<Self> {
+    pub fn new(based_on: Vec<String>, copied_from: String, description: String) -> Result<Self> {
         if description.trim().is_empty() {
             bail!("Please provide a description for the model")
         }
@@ -215,7 +211,8 @@ pub fn update_metadata_file(
             m.update(description, tags_vec, based_on_vec)
         }
     } else {
-        let mut m = ModelMetadata::new(based_on_vec, None, description.unwrap_or_default())?;
+        let mut m =
+            ModelMetadata::new(based_on_vec, String::new(), description.unwrap_or_default())?;
         m.tags = tags_vec;
         m
     };
@@ -229,6 +226,7 @@ pub fn clear_metadata_file(
     model_dir: impl AsRef<Path>,
     metadata_path: impl AsRef<Path>,
     clear_based_on: bool,
+    clear_copied_from: bool,
     clear_tags: bool,
 ) -> Result<PathBuf> {
     let model_dir = model_dir.as_ref();
@@ -236,16 +234,18 @@ pub fn clear_metadata_file(
 
     let mut metadata = ModelMetadata::load(metadata_path)?;
 
-    // Clear fields based on flags
     if clear_based_on {
         metadata.based_on.clear();
+    }
+
+    if clear_copied_from {
+        metadata.copied_from.clear();
     }
 
     if clear_tags {
         metadata.tags.clear();
     }
 
-    // Save updated metadata (description is preserved)
     metadata.save(&model_name, model_dir)?;
     Ok(metadata_path.to_path_buf())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,6 +204,9 @@ pub enum NonmemMetadata {
         /// Clear the based_on field
         #[clap(long)]
         based_on: bool,
+        /// Clear the copied_from field
+        #[clap(long)]
+        copied_from: bool,
         /// Clear the tags field
         #[clap(long)]
         tags: bool,
@@ -864,6 +867,7 @@ fn try_main() -> Result<()> {
                 NonmemMetadata::Clear {
                     model_path,
                     based_on,
+                    copied_from,
                     tags,
                 } => {
                     let (model_name, model_dir) = nonmem::validate_model_path(&model_path)?;
@@ -882,6 +886,7 @@ fn try_main() -> Result<()> {
                         model_dir,
                         metadata_path,
                         based_on,
+                        copied_from,
                         tags,
                     )?;
                     println!("Metadata fields cleared at {path:?}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,9 @@ pub enum NonmemMetadata {
         /// Comma-separated list of model paths this one is based on (relative to model directory)
         #[clap(long, value_delimiter = ',')]
         based_on: Vec<String>,
+        /// Path of the model this was copied from (relative to model directory)
+        #[clap(long)]
+        copied_from: Option<String>,
     },
     /// Append to existing metadata (file must already exist)
     Append {
@@ -833,6 +836,7 @@ fn try_main() -> Result<()> {
                     description,
                     tags,
                     based_on,
+                    copied_from,
                 } => {
                     if let Some(d) = &description
                         && d.trim().is_empty()
@@ -845,6 +849,7 @@ fn try_main() -> Result<()> {
                         description,
                         tags,
                         based_on,
+                        copied_from,
                         true, // Use overwrite=true for 'set' command
                     )?;
                     println!("Metadata file set at {path:?}");
@@ -860,6 +865,7 @@ fn try_main() -> Result<()> {
                         description,
                         tags,
                         based_on,
+                        None,
                         false, // Use overwrite=false for 'append' command
                     )?;
                     println!("Metadata file updated at {path:?}");


### PR DESCRIPTION
Updates `ModelMetadata` to differentiate where model's were copied from and if they are nested models allowing statistical comparisons.

```
❯ cargo run -- nonmem lineage ../hyperion/inst/extdata/models/onecmt
    Finished `dev` profile [unoptimized] target(s) in 0.20s
     Running `target/debug/pharos nonmem lineage ../hyperion/inst/extdata/models/onecmt`
+----------------+------------+---------+--------------+-------------+----------------------------------------------------------------------------------------+------+
| Model          | Parents    | Runtime | Dataset Hash | Model Hash  | Description                                                                            | Tags |
+----------------+------------+---------+--------------+-------------+----------------------------------------------------------------------------------------+------+
| run001.mod     | -          | 10.2s   | 8d8189cf...  | f873a13c... | Base model                                                                             | base |
| run002.mod     | run001.mod | 8.5s    | 8d8189cf...  | 1a0f07a1... | Adding COV step, unfixing eps(2)                                                       | -    |
| run004.mod     | run001.mod | N/A     | N/A          | N/A         | Updating run001 to run004 with jittered params and updated initials                    | -    |
| run005.mod     | run001.mod | N/A     | N/A          | N/A         | Updating run001 to run004 with jittered params and updated initials                    | -    |
| run002a.mod    | run002.mod | N/A     | N/A          | N/A         | Some description about what makes run002a different                                    | -    |
| run002b001.mod | run002.mod | N/A     | N/A          | N/A         | Jittering initial sigma estimates, using theta/omega final estimates. Adding covariate | -    |
| run003.mod     | run002.mod | N/A     | 8d8189cf...  | 125037f8... | Jittering initial estimates                                                            | key  |
| run003b1.mod   | run003.mod | 10.2s   | df6cbcde...  | cdca6ed2... | Updating run003 to 003b1 with jittered params. Adding WT on V                          | -    |
| run003b2.mod   | run003.mod | N/A     | N/A          | N/A         | Updating run003 with mod object                                                        | -    |
+----------------+------------+---------+--------------+-------------+----------------------------------------------------------------------------------------+------+
```

Now copying a model sets `copied_from` instead of `based_on`
```
{
  "based_on": [],
  "copied_from": "run003.mod",
  "description": "Testing new copied_from metadata",
  "tags": []
}
```
and lineage shows run003ct.mod as a new root with no parents.
```
❯ cargo run -- nonmem lineage ../hyperion/inst/extdata/models/onecmt
    Finished `dev` profile [unoptimized] target(s) in 0.22s
     Running `target/debug/pharos nonmem lineage ../hyperion/inst/extdata/models/onecmt`
+----------------+------------+---------+--------------+-------------+----------------------------------------------------------------------------------------+------+
| Model          | Parents    | Runtime | Dataset Hash | Model Hash  | Description                                                                            | Tags |
+----------------+------------+---------+--------------+-------------+----------------------------------------------------------------------------------------+------+
| run001.mod     | -          | 10.2s   | 8d8189cf...  | f873a13c... | Base model                                                                             | base |
| run003ct.mod   | -          | N/A     | N/A          | N/A         | Testing new copied_from metadata                                                       | -    |
| run002.mod     | run001.mod | 8.5s    | 8d8189cf...  | 1a0f07a1... | Adding COV step, unfixing eps(2)                                                       | -    |
| run004.mod     | run001.mod | N/A     | N/A          | N/A         | Updating run001 to run004 with jittered params and updated initials                    | -    |
| run005.mod     | run001.mod | N/A     | N/A          | N/A         | Updating run001 to run004 with jittered params and updated initials                    | -    |
| run002a.mod    | run002.mod | N/A     | N/A          | N/A         | Some description about what makes run002a different                                    | -    |
| run002b001.mod | run002.mod | N/A     | N/A          | N/A         | Jittering initial sigma estimates, using theta/omega final estimates. Adding covariate | -    |
| run003.mod     | run002.mod | 15.2s   | 8d8189cf...  | 125037f8... | Jittering initial estimates                                                            | key  |
| run003b1.mod   | run003.mod | 10.2s   | df6cbcde...  | cdca6ed2... | Updating run003 to 003b1 with jittered params. Adding WT on V                          | -    |
| run003b2.mod   | run003.mod | N/A     | N/A          | N/A         | Updating run003 with mod object                                                        | -    |
+----------------+------------+---------+--------------+-------------+----------------------------------------------------------------------------------------+------+
```

The `based-on` flag for copy allows a user to set it during copy:
```
❯ cargo run -- nonmem copy --from ../hyperion/inst/extdata/models/onecmt/run003.mod --to ../hyperion/inst/extdata/models/onecmt/run003cb.mod --update "all" --description "Testing new copied_from metadata with based on" --based-on run003.mod
    Finished `dev` profile [unoptimized] target(s) in 0.05s
     Running `target/debug/pharos nonmem copy --from ../hyperion/inst/extdata/models/onecmt/run003.mod --to ../hyperion/inst/extdata/models/onecmt/run003cb.mod --update all --description 'Testing new copied_from metadata with based on' --based-on run003.mod`
```

Now run003cb.mod shows run003 as parent:
```
❯ cargo run -- nonmem lineage ../hyperion/inst/extdata/models/onecmt
    Finished `dev` profile [unoptimized] target(s) in 0.25s
     Running `target/debug/pharos nonmem lineage ../hyperion/inst/extdata/models/onecmt`
+----------------+------------+---------+--------------+-------------+----------------------------------------------------------------------------------------+------+
| Model          | Parents    | Runtime | Dataset Hash | Model Hash  | Description                                                                            | Tags |
+----------------+------------+---------+--------------+-------------+----------------------------------------------------------------------------------------+------+
| run001.mod     | -          | 10.2s   | 8d8189cf...  | f873a13c... | Base model                                                                             | base |
| run003ct.mod   | -          | N/A     | N/A          | N/A         | Testing new copied_from metadata                                                       | -    |
| run002.mod     | run001.mod | 8.5s    | 8d8189cf...  | 1a0f07a1... | Adding COV step, unfixing eps(2)                                                       | -    |
| run004.mod     | run001.mod | N/A     | N/A          | N/A         | Updating run001 to run004 with jittered params and updated initials                    | -    |
| run005.mod     | run001.mod | N/A     | N/A          | N/A         | Updating run001 to run004 with jittered params and updated initials                    | -    |
| run002a.mod    | run002.mod | N/A     | N/A          | N/A         | Some description about what makes run002a different                                    | -    |
| run002b001.mod | run002.mod | N/A     | N/A          | N/A         | Jittering initial sigma estimates, using theta/omega final estimates. Adding covariate | -    |
| run003.mod     | run002.mod | N/A     | 8d8189cf...  | 125037f8... | Jittering initial estimates                                                            | key  |
| run003b1.mod   | run003.mod | 10.2s   | df6cbcde...  | cdca6ed2... | Updating run003 to 003b1 with jittered params. Adding WT on V                          | -    |
| run003b2.mod   | run003.mod | N/A     | N/A          | N/A         | Updating run003 with mod object                                                        | -    |
| run003cb.mod   | run003.mod | N/A     | N/A          | N/A         | Testing new copied_from metadata with based on                                         | -    |
+----------------+------------+---------+--------------+-------------+----------------------------------------------------------------------------------------+------+
```

