### PR TITLE
Copy ext

### DIFF
--- a/components/nonmem/src/output_files/mod.rs
+++ b/components/nonmem/src/output_files/mod.rs
@@ -66,7 +66,14 @@ impl Summary {
 /// inheritance rule (an `$EST` without `FILE=` continues writing to the previous
 /// `$EST`'s file). Falls back to `default` when no `$EST` has set a file yet, or
 /// when the model has no `$EST` records.
-fn resolve_estimation_files(model: &Model, directory: &Path, default: &Path) -> Vec<PathBuf> {
+pub fn resolve_estimation_files(
+    model: &Model,
+    directory: impl AsRef<Path>,
+    default: impl AsRef<Path>,
+) -> Vec<PathBuf> {
+    let directory = directory.as_ref();
+    let default = default.as_ref();
+
     if model.estimations.is_empty() {
         return vec![default.to_path_buf()];
     }

--- a/components/nonmem/src/run/setup.rs
+++ b/components/nonmem/src/run/setup.rs
@@ -38,7 +38,6 @@ pub fn prepare_model(
     }
 
     let parent_dir = path.parent().expect("models to not be at the root of FS");
-    let file_name = path.file_name().expect("models to have a filename");
     let model_name = path
         .file_stem()
         .expect("models to have a filename")
@@ -46,7 +45,7 @@ pub fn prepare_model(
         .to_string(); // e.g., "run001"
 
     let output_dir_name = if let Some(o) = output_dir {
-        render_output_dir_template(&o, &file_name.to_string_lossy())?
+        render_output_dir_template(&o, &model_name)?
     } else {
         model_name.clone()
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,13 +326,6 @@ fn find_output_folder(
         .ok_or_else(|| anyhow!("Could not determine model file stem"))?
         .to_string_lossy();
 
-    // Templated output dirs are rendered with the full filename (including
-    // extension) by run/setup.rs, so match that here.
-    let file_name = model_path
-        .file_name()
-        .ok_or_else(|| anyhow!("Could not determine model file name"))?
-        .to_string_lossy();
-
     let root_folder = model_path
         .parent()
         .ok_or_else(|| anyhow!("Could not determine parent directory"))?;
@@ -347,7 +340,7 @@ fn find_output_folder(
     let mut possible_folders = vec![model_name.as_ref().to_string()];
 
     if let Some(o) = &config.output_dir
-        && let Ok(o2) = render_output_dir_template(o, file_name.as_ref())
+        && let Ok(o2) = render_output_dir_template(o, model_name.as_ref())
     {
         possible_folders.push(o2);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ use config::{CONFIG_FILENAME, Config, NonmemConfig, find_config_dir, render_outp
 use fs_err as fs;
 use nonmem::expand_model_pattern;
 use nonmem::output_files::ext::ParameterType;
-use nonmem::output_files::get_summary;
-use nonmem::{CopyOptions, LineageTree, RunOptions, check_model, copy_model, run_models};
+use nonmem::output_files::{get_summary, resolve_estimation_files};
+use nonmem::{CopyOptions, LineageTree, Model, RunOptions, check_model, copy_model, run_models};
 use scheduler::{SchedulerType, sge, slurm};
 use serde_json::json;
 
@@ -330,7 +330,13 @@ fn find_output_folder(
         .parent()
         .ok_or_else(|| anyhow!("Could not determine parent directory"))?;
 
-    // First look up if there is an output dir
+    // Parse the source model so we can honor `$EST FILE=` overrides when
+    // discovering the .ext file. If parsing fails, fall through to the default
+    // name — the parse error will resurface in copy_model.
+    let model = fs::read_to_string(model_path)
+        .ok()
+        .and_then(|s| Model::parse(&s).ok());
+
     let mut possible_folders = vec![model_name.as_ref().to_string()];
 
     if let Some(o) = &config.output_dir
@@ -340,9 +346,17 @@ fn find_output_folder(
     }
 
     for f in possible_folders {
-        let p = root_folder.join(f).join(format!("{}.ext", model_name));
-        if p.exists() {
-            return Ok(Some(p));
+        let folder = root_folder.join(f);
+        let default = folder.join(format!("{}.ext", model_name));
+        let candidate = match &model {
+            Some(m) => resolve_estimation_files(m, &folder, &default)
+                .last()
+                .cloned()
+                .unwrap_or(default),
+            None => default,
+        };
+        if candidate.exists() {
+            return Ok(Some(candidate));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,6 +326,13 @@ fn find_output_folder(
         .ok_or_else(|| anyhow!("Could not determine model file stem"))?
         .to_string_lossy();
 
+    // Templated output dirs are rendered with the full filename (including
+    // extension) by run/setup.rs, so match that here.
+    let file_name = model_path
+        .file_name()
+        .ok_or_else(|| anyhow!("Could not determine model file name"))?
+        .to_string_lossy();
+
     let root_folder = model_path
         .parent()
         .ok_or_else(|| anyhow!("Could not determine parent directory"))?;
@@ -340,7 +347,7 @@ fn find_output_folder(
     let mut possible_folders = vec![model_name.as_ref().to_string()];
 
     if let Some(o) = &config.output_dir
-        && let Ok(o2) = render_output_dir_template(o, model_name.as_ref())
+        && let Ok(o2) = render_output_dir_template(o, file_name.as_ref())
     {
         possible_folders.push(o2);
     }


### PR DESCRIPTION
make `nonmem copy` use the ext resolver. Fixed bug with output_dir config not using model name, but file name. 


https://github.com/user-attachments/assets/cb4888e8-50f3-4fc4-a2e6-734d1b15f22a

