### PR TITLE
make directories instead of failing

### DIFF
--- a/components/nonmem-parser/src/model/copy.rs
+++ b/components/nonmem-parser/src/model/copy.rs
@@ -163,6 +163,13 @@ impl Model {
         new_model
     }
 
+    pub fn update_data_path(&mut self, new_path: &str) {
+        if let Some(idx) = self.data.path_idx {
+            self.tokens[idx].text = new_path.to_string();
+        }
+        self.data.path = new_path.to_string();
+    }
+
     pub fn update_table_path(&mut self, index: usize, new_path: &str) {
         if let Some(table) = self.tables.get_mut(index) {
             if let Some(idx) = table.file_idx {

--- a/components/nonmem-parser/src/model/copy.rs
+++ b/components/nonmem-parser/src/model/copy.rs
@@ -165,7 +165,13 @@ impl Model {
 
     pub fn update_data_path(&mut self, new_path: &str) {
         if let Some(idx) = self.data.path_idx {
-            self.tokens[idx].text = new_path.to_string();
+            let tok = &mut self.tokens[idx];
+            tok.text = if tok.token == Token::QuotedString {
+                let quote = tok.text.chars().next().unwrap_or('"');
+                format!("{quote}{new_path}{quote}")
+            } else {
+                new_path.to_string()
+            };
         }
         self.data.path = new_path.to_string();
     }
@@ -339,6 +345,29 @@ $TABLE ID FILE=../output/run001.tab
         assert!(modified.contains("FILE=run001.tab"));
         assert!(!modified.contains("../output/"));
         assert!(!modified.contains("../data/"));
+    }
+
+    #[test]
+    fn update_data_path_preserves_quoting() {
+        // A path containing a space must stay quoted to remain a valid $DATA path.
+        let input = "\
+$PROBLEM test
+$INPUT ID
+$DATA \"../my data/file.csv\" IGNORE=@
+$THETA 1
+";
+        let mut model = parse_model(input);
+        // The parsed value is unquoted...
+        assert_eq!(model.data.path, "../my data/file.csv");
+
+        model.update_data_path("../../my data/file.csv");
+
+        // ...but rendering back out must re-apply the original quotes.
+        let content = model.model_content();
+        assert!(
+            content.contains("$DATA \"../../my data/file.csv\" IGNORE=@"),
+            "expected quotes to be preserved, got:\n{content}"
+        );
     }
 
     #[test]

--- a/components/nonmem/src/copy.rs
+++ b/components/nonmem/src/copy.rs
@@ -309,11 +309,10 @@ fn rebase_relative_path(rel_path: &str, from_dir: &Path, to_dir: &Path) -> Optio
     let target = normalize_path(&cwd.join(from_dir).join(rel_path));
     let to_abs = normalize_path(&cwd.join(to_dir));
     let new_rel = relative_path_from(&target, &to_abs);
-    let new_rel = new_rel.to_string_lossy();
     if new_rel == rel_path {
         None
     } else {
-        Some(new_rel.into_owned())
+        Some(new_rel)
     }
 }
 
@@ -338,7 +337,9 @@ fn normalize_path(path: &Path) -> PathBuf {
 }
 
 /// Express `target` relative to `base`, assuming both are normalized absolute paths.
-fn relative_path_from(target: &Path, base: &Path) -> PathBuf {
+/// Components are joined with `/` (not the OS separator) so the result stays portable
+/// inside the model file regardless of the platform the copy runs on.
+fn relative_path_from(target: &Path, base: &Path) -> String {
     let target_comps: Vec<_> = target.components().collect();
     let base_comps: Vec<_> = base.components().collect();
     let common = target_comps
@@ -347,14 +348,14 @@ fn relative_path_from(target: &Path, base: &Path) -> PathBuf {
         .take_while(|(a, b)| a == b)
         .count();
 
-    let mut result = PathBuf::new();
+    let mut parts: Vec<String> = Vec::new();
     for _ in common..base_comps.len() {
-        result.push("..");
+        parts.push("..".to_string());
     }
     for comp in &target_comps[common..] {
-        result.push(comp.as_os_str());
+        parts.push(comp.as_os_str().to_string_lossy().into_owned());
     }
-    result
+    parts.join("/")
 }
 
 #[cfg(test)]

--- a/components/nonmem/src/copy.rs
+++ b/components/nonmem/src/copy.rs
@@ -323,13 +323,17 @@ fn normalize_path(path: &Path) -> PathBuf {
     for comp in path.components() {
         match comp {
             Component::CurDir => {}
-            Component::ParentDir => {
-                if matches!(out.components().next_back(), Some(Component::Normal(_))) {
+            Component::ParentDir => match out.components().next_back() {
+                // Collapse against a directory we actually descended into.
+                Some(Component::Normal(_)) => {
                     out.pop();
-                } else {
-                    out.push("..");
                 }
-            }
+                // At an absolute root (or drive prefix) `..` has nowhere to go, so
+                // clamp — matching how the OS resolves it — rather than emit `/..`.
+                Some(Component::RootDir | Component::Prefix(_)) => {}
+                // Relative path with no parent to pop: keep `..` to preserve depth.
+                _ => out.push(".."),
+            },
             other => out.push(other.as_os_str()),
         }
     }

--- a/components/nonmem/src/copy.rs
+++ b/components/nonmem/src/copy.rs
@@ -260,6 +260,17 @@ pub fn copy_model(
 
     let new_model_name = to.file_stem().unwrap().to_string_lossy();
 
+    // A relative $DATA path is resolved relative to the model's own directory, so
+    // moving the model to a different directory would break it. Rewrite it to point
+    // at the same dataset from the new location. Absolute paths are left untouched.
+    if Path::new(&new_model.data.path).is_relative() {
+        let from_dir = from.parent().unwrap_or(Path::new("."));
+        let to_dir = to.parent().unwrap_or(Path::new("."));
+        if let Some(new_data_path) = rebase_relative_path(&new_model.data.path, from_dir, to_dir) {
+            new_model.update_data_path(&new_data_path);
+        }
+    }
+
     // Ensure the destination directory exists so metadata and model writes succeed
     if let Some(parent) = to.parent().filter(|p| !p.as_os_str().is_empty()) {
         fs::create_dir_all(parent)?;
@@ -288,4 +299,99 @@ pub fn copy_model(
     f.write_all(new_model.model_content().as_bytes())?;
 
     Ok(())
+}
+
+/// Re-express a relative path written against `from_dir` so that it resolves to the
+/// same target from `to_dir`. Returns `None` if the result equals the input (no move).
+/// Purely lexical — does not touch the filesystem, so the dataset need not exist.
+fn rebase_relative_path(rel_path: &str, from_dir: &Path, to_dir: &Path) -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    let target = normalize_path(&cwd.join(from_dir).join(rel_path));
+    let to_abs = normalize_path(&cwd.join(to_dir));
+    let new_rel = relative_path_from(&target, &to_abs);
+    let new_rel = new_rel.to_string_lossy();
+    if new_rel == rel_path {
+        None
+    } else {
+        Some(new_rel.into_owned())
+    }
+}
+
+/// Lexically resolve `.` and `..` components without consulting the filesystem.
+fn normalize_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut out = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if matches!(out.components().next_back(), Some(Component::Normal(_))) {
+                    out.pop();
+                } else {
+                    out.push("..");
+                }
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// Express `target` relative to `base`, assuming both are normalized absolute paths.
+fn relative_path_from(target: &Path, base: &Path) -> PathBuf {
+    let target_comps: Vec<_> = target.components().collect();
+    let base_comps: Vec<_> = base.components().collect();
+    let common = target_comps
+        .iter()
+        .zip(&base_comps)
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let mut result = PathBuf::new();
+    for _ in common..base_comps.len() {
+        result.push("..");
+    }
+    for comp in &target_comps[common..] {
+        result.push(comp.as_os_str());
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Absolute dirs so the result is independent of the test's working directory.
+    fn rebase(rel: &str, from: &str, to: &str) -> Option<String> {
+        rebase_relative_path(rel, Path::new(from), Path::new(to))
+    }
+
+    #[test]
+    fn sibling_dirs_same_depth_keeps_path() {
+        // ../../data/pk.csv resolves to the same place from a sibling dir.
+        assert_eq!(
+            rebase(
+                "../../data/pk.csv",
+                "/proj/models/onecmt",
+                "/proj/models/twocmt"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn dataset_in_model_dir_points_back() {
+        assert_eq!(
+            rebase("pk.csv", "/proj/models/onecmt", "/proj/models/twocmt"),
+            Some("../onecmt/pk.csv".to_string())
+        );
+    }
+
+    #[test]
+    fn deeper_subdir_adds_parent_segments() {
+        assert_eq!(
+            rebase("../data/pk.csv", "/proj/models", "/proj/models/a/b/c"),
+            Some("../../../../data/pk.csv".to_string())
+        );
+    }
 }

--- a/components/nonmem/src/copy.rs
+++ b/components/nonmem/src/copy.rs
@@ -368,31 +368,37 @@ mod tests {
     }
 
     #[test]
-    fn sibling_dirs_same_depth_keeps_path() {
-        // ../../data/pk.csv resolves to the same place from a sibling dir.
-        assert_eq!(
-            rebase(
+    fn rebase_relative_path_cases() {
+        let cases = [
+            // Sibling dirs at the same depth resolve to the same place, so no rebase.
+            (
                 "../../data/pk.csv",
                 "/proj/models/onecmt",
-                "/proj/models/twocmt"
+                "/proj/models/twocmt",
+                None,
             ),
-            None
-        );
-    }
+            // Dataset in the model dir must point back to the original dir.
+            (
+                "pk.csv",
+                "/proj/models/onecmt",
+                "/proj/models/twocmt",
+                Some("../onecmt/pk.csv"),
+            ),
+            // Deeper destination adds parent segments.
+            (
+                "../data/pk.csv",
+                "/proj/models",
+                "/proj/models/a/b/c",
+                Some("../../../../data/pk.csv"),
+            ),
+        ];
 
-    #[test]
-    fn dataset_in_model_dir_points_back() {
-        assert_eq!(
-            rebase("pk.csv", "/proj/models/onecmt", "/proj/models/twocmt"),
-            Some("../onecmt/pk.csv".to_string())
-        );
-    }
-
-    #[test]
-    fn deeper_subdir_adds_parent_segments() {
-        assert_eq!(
-            rebase("../data/pk.csv", "/proj/models", "/proj/models/a/b/c"),
-            Some("../../../../data/pk.csv".to_string())
-        );
+        for (rel, from, to, expected) in cases {
+            assert_eq!(
+                rebase(rel, from, to),
+                expected.map(str::to_string),
+                "rebase({rel:?}, {from:?}, {to:?})"
+            );
+        }
     }
 }

--- a/components/nonmem/src/copy.rs
+++ b/components/nonmem/src/copy.rs
@@ -260,6 +260,11 @@ pub fn copy_model(
 
     let new_model_name = to.file_stem().unwrap().to_string_lossy();
 
+    // Ensure the destination directory exists so metadata and model writes succeed
+    if let Some(parent) = to.parent().filter(|p| !p.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)?;
+    }
+
     // Create metadata file
     if !options.no_metadata {
         let model_dir = to


### PR DESCRIPTION
```
matthews@devcluster|LoginNode devcluster:~/Packages/hyperion$ pharos nonmem copy --from inst/extdata/models/onecmt/run003.mod --to inst/extdata/models/twocmt/run103.mod --update all 
--jitter 0.1 --description "Two compartment model"
failed to create file `inst/extdata/models/twocmt/run103_metadata.json`: No such file or directory (os error 2)
```

Could not copy model to new directory. 

```
matthews@devcluster|LoginNode devcluster:~/Packages/hyperion$ ls inst/extdata/models/twocmt/
ls: cannot access 'inst/extdata/models/twocmt/': No such file or directory
matthews@devcluster|LoginNode devcluster:~/Packages/hyperion$ pharos nonmem copy --from inst/extdata/models/onecmt/run003.mod --to inst/extdata/models/twocmt/run103.mod --update all --jitter 0.1 --description "Two compartment model"
matthews@devcluster|LoginNode devcluster:~/Packages/hyperion$ ls inst/extdata/models/twocmt/
run103.mod  run103_metadata.json
```

If copied model is different depth $DATA path is updated accordingly if relative:

```
matthews@devcluster|LoginNode devcluster:~/Packages/hyperion$ pharos nonmem copy --from inst/extdata/models/onecmt/run003.mod --to inst/extdata/models/twocmt/but/deeper/run103.mod --
update all --jitter 0.1 --description "Two compartment model different depts"
```
run003 $DATA:
```
matthews@devcluster|LoginNode devcluster:~/Packages/hyperion$ cat inst/extdata/models/onecmt/run003.mod 
$PROBLEM Base one-compartment oral absorption model created from pharos see run003_metadata.json for details.

$INPUT ID TIME EVID AMT CMT DV MDV WT SEX

$DATA ../../data/derived/onecmpt-oral-30ind.csv IGNORE=@
```
run103.mod $DATA
```
matthews@devcluster|LoginNode devcluster:~/Packages/hyperion$ cat inst/extdata/models/twocmt/but/deeper/run103.mod 
$PROBLEM Base one-compartment oral absorption model created from pharos see run103_metadata.json for details.

$INPUT ID TIME EVID AMT CMT DV MDV WT SEX

$DATA ../../../../data/derived/onecmpt-oral-30ind.csv IGNORE=@
```